### PR TITLE
Enhance backup and restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ Available commands:
 - `seed` – seed the local database
 - `create <env>` – clone the base `pb_data`, start a remote container, apply migrations and seeds, and configure nginx at `<env>.<domain>`
 - `destroy <env>` – stop the container, remove its data and nginx config
-- `backup <env>` – zip the remote data directory
-- `restore <env> <file>` – restore a backup on the remote server
+- `backup <env>` – create a ZIP of the remote data directory. Use `--local` to
+  download it and `--remote` to keep a copy on the server.
+- `restore <env> <file>` – stop the remote container, restore the ZIP, and start
+  the container again
 - `deploy <env>` – create and apply migrations & seeds
 


### PR DESCRIPTION
## Summary
- allow backing up to local machine with `--local` and keeping remote backups with `--remote`
- upload backup for restore after stopping the container and restarting it
- document new backup & restore behaviour

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6847d3f6cf108331bb620b5c17457699