### PR TITLE
Add pull command to pb-manage

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,5 +22,6 @@ Available commands:
   download it and `--remote` to keep a copy on the server.
 - `restore <env> <file>` – stop the remote container, restore the ZIP, and start
   the container again
+- `pull <env>` – fetch a remote backup and restore it locally
 - `deploy <env>` – create and apply migrations & seeds
 


### PR DESCRIPTION
## Summary
- add `pull` command to pb-manage for syncing local data from a remote env
- document the new command in README

## Testing
- `node -c pb-manage/bin/pb-manage.js`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6847d5eb34488331a075c3bb878f1bc5