### PR TITLE
Add pb-manage tests

### DIFF
--- a/pb-manage/package.json
+++ b/pb-manage/package.json
@@ -7,5 +7,8 @@
   "private": true,
   "dependencies": {
     "minimist": "^1.2.8"
+  },
+  "scripts": {
+    "test": "node --test"
   }
 }

--- a/pb-manage/tests/cli.test.js
+++ b/pb-manage/tests/cli.test.js
@@ -1,0 +1,34 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const bin = path.resolve(__dirname, '..', 'bin', 'pb-manage.js');
+
+test('shows usage with no command', () => {
+  const res = spawnSync('node', [bin], { encoding: 'utf8' });
+  assert.match(res.stdout, /Usage: pb-manage/);
+  assert.strictEqual(res.status, 0);
+});
+
+test('init creates project files', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pbtest-'));
+  const res = spawnSync('node', [bin, 'init'], { cwd: dir, encoding: 'utf8' });
+  assert.strictEqual(res.status, 0);
+  const files = ['pb.config.json', 'Dockerfile', 'docker-compose.yml', 'nginx.conf'];
+  for (const f of files) {
+    assert.ok(fs.existsSync(path.join(dir, f)), `${f} should exist`);
+  }
+  const dirs = ['pb_migrations', 'pb_seeds'];
+  for (const d of dirs) {
+    assert.ok(fs.existsSync(path.join(dir, d)), `${d} should exist`);
+  }
+});
+
+test('create without env prints error', () => {
+  const res = spawnSync('node', [bin, 'create'], { encoding: 'utf8' });
+  assert.match(res.stderr, /Missing environment name/);
+  assert.strictEqual(res.status, 0);
+});


### PR DESCRIPTION
## Summary
- set up Node built-in test script for pb-manage
- create tests directory with basic CLI tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6847df5ed8c48331a636a84e2e59f028