### PR TITLE
Add pb-manage tests

### DIFF
--- a/pb-manage/bin/pb-manage.js
+++ b/pb-manage/bin/pb-manage.js
@@ -281,16 +281,41 @@ function deploy(env = argv.env) {
   seed();
 }
 
-const cmd = argv._[0];
-if (!cmd) return usage();
-if (cmd === 'init') init();
-else if (cmd === 'dev') dev();
-else if (cmd === 'migrate') migrate();
-else if (cmd === 'seed') seed();
-else if (cmd === 'create') create(argv._[1]);
-else if (cmd === 'destroy') destroy(argv._[1]);
-else if (cmd === 'backup') backup(argv._[1]);
-else if (cmd === 'restore') restore(argv._[1], argv._[2]);
-else if (cmd === 'pull') pull(argv._[1]);
-else if (cmd === 'deploy') deploy(argv._[1]);
-else usage();
+if (require.main === module) {
+  const cmd = argv._[0];
+  if (!cmd) return usage();
+  if (cmd === 'init') init();
+  else if (cmd === 'dev') dev();
+  else if (cmd === 'migrate') migrate();
+  else if (cmd === 'seed') seed();
+  else if (cmd === 'create') create(argv._[1]);
+  else if (cmd === 'destroy') destroy(argv._[1]);
+  else if (cmd === 'backup') backup(argv._[1]);
+  else if (cmd === 'restore') restore(argv._[1], argv._[2]);
+  else if (cmd === 'pull') pull(argv._[1]);
+  else if (cmd === 'deploy') deploy(argv._[1]);
+  else usage();
+} else {
+  module.exports = {
+    argv,
+    loadConfig,
+    run,
+    ssh,
+    scpFromRemote,
+    scpToRemote,
+    ensureDir,
+    writeFileIfMissing,
+    ensureDockerRunning,
+    init,
+    dev,
+    migrate,
+    seed,
+    create,
+    destroy,
+    backup,
+    restore,
+    pull,
+    deploy,
+    usage,
+  };
+}

--- a/pb-manage/package.json
+++ b/pb-manage/package.json
@@ -7,5 +7,8 @@
   "private": true,
   "dependencies": {
     "minimist": "^1.2.8"
+  },
+  "scripts": {
+    "test": "node --test"
   }
 }

--- a/pb-manage/tests/cli.test.js
+++ b/pb-manage/tests/cli.test.js
@@ -1,0 +1,34 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const bin = path.resolve(__dirname, '..', 'bin', 'pb-manage.js');
+
+test('shows usage with no command', () => {
+  const res = spawnSync('node', [bin], { encoding: 'utf8' });
+  assert.match(res.stdout, /Usage: pb-manage/);
+  assert.strictEqual(res.status, 0);
+});
+
+test('init creates project files', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pbtest-'));
+  const res = spawnSync('node', [bin, 'init'], { cwd: dir, encoding: 'utf8' });
+  assert.strictEqual(res.status, 0);
+  const files = ['pb.config.json', 'Dockerfile', 'docker-compose.yml', 'nginx.conf'];
+  for (const f of files) {
+    assert.ok(fs.existsSync(path.join(dir, f)), `${f} should exist`);
+  }
+  const dirs = ['pb_migrations', 'pb_seeds'];
+  for (const d of dirs) {
+    assert.ok(fs.existsSync(path.join(dir, d)), `${d} should exist`);
+  }
+});
+
+test('create without env prints error', () => {
+  const res = spawnSync('node', [bin, 'create'], { encoding: 'utf8' });
+  assert.match(res.stderr, /Missing environment name/);
+  assert.strictEqual(res.status, 0);
+});

--- a/pb-manage/tests/commands.test.js
+++ b/pb-manage/tests/commands.test.js
@@ -1,0 +1,154 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const script = path.resolve(__dirname, '..', 'bin', 'pb-manage.js');
+
+function withExecStub(fn) {
+  const cp = require('child_process');
+  const orig = cp.execSync;
+  const cmds = [];
+  cp.execSync = (cmd) => { cmds.push(cmd); };
+  try {
+    return fn(cmds);
+  } finally {
+    cp.execSync = orig;
+  }
+}
+
+function freshModule() {
+  delete require.cache[require.resolve(script)];
+  return require(script);
+}
+
+function withTempConfig(fn) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pbtest-'));
+  const cfg = {
+    vpsHost: 'host',
+    sshUser: 'root',
+    domain: 'example.com'
+  };
+  fs.writeFileSync(path.join(dir, 'pb.config.json'), JSON.stringify(cfg));
+  const cwd = process.cwd();
+  process.chdir(dir);
+  try {
+    return fn(dir);
+  } finally {
+    process.chdir(cwd);
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// init
+test('init creates config file', () => {
+  withTempConfig((dir) => {
+    fs.unlinkSync(path.join(dir, 'pb.config.json')); // remove to test creation
+    const { init } = freshModule();
+    init();
+    assert.ok(fs.existsSync(path.join(dir, 'pb.config.json')));
+  });
+});
+
+// migrate
+test('migrate runs docker migrate', () => {
+  withExecStub((cmds) => {
+    const { migrate } = freshModule();
+    migrate();
+    assert.deepStrictEqual(cmds, ['docker-compose exec pocketbase pocketbase migrate up']);
+  });
+});
+
+// seed
+test('seed runs docker seed', () => {
+  withExecStub((cmds) => {
+    const { seed } = freshModule();
+    seed();
+    assert.deepStrictEqual(cmds, ['docker-compose exec pocketbase pocketbase seed up']);
+  });
+});
+
+// dev
+test('dev starts containers', () => {
+  withExecStub((cmds) => {
+    const { dev } = freshModule();
+    dev();
+    assert.ok(cmds.includes('docker-compose up -d --build'));
+  });
+});
+
+// create
+test('create issues ssh commands', () => {
+  withTempConfig(() => {
+    withExecStub((cmds) => {
+      const { create } = freshModule();
+      create('dev');
+      assert.ok(cmds.some(c => c.includes('docker run -d --name pb-dev')));
+    });
+  });
+});
+
+// destroy
+test('destroy removes remote instance', () => {
+  withTempConfig(() => {
+    withExecStub((cmds) => {
+      const { destroy } = freshModule();
+      destroy('dev');
+      assert.ok(cmds.some(c => c.includes('docker rm -f pb-dev')));
+    });
+  });
+});
+
+// backup
+test('backup pulls backup when local flag set', () => {
+  withTempConfig(() => {
+    withExecStub((cmds) => {
+      const mod = freshModule();
+      mod.argv.local = true;
+      mod.argv.remote = false;
+      mod.backup('dev');
+      assert.ok(cmds.some(c => c.includes("zip -r /tmp/dev-backup.zip")));
+      assert.ok(cmds.some(c => c.startsWith('scp ')));
+    });
+  });
+});
+
+// restore
+test('restore uploads and restarts', () => {
+  withTempConfig((dir) => {
+    withExecStub((cmds) => {
+      const file = path.join(dir, 'data.zip');
+      fs.writeFileSync(file, 'dummy');
+      const { restore } = freshModule();
+      restore('dev', file);
+      assert.ok(cmds.some(c => c.startsWith('scp ')));
+      assert.ok(cmds.some(c => c.includes('docker start pb-dev')));
+    });
+  });
+});
+
+// pull
+test('pull grabs remote data', () => {
+  withTempConfig(() => {
+    withExecStub((cmds) => {
+      const { pull } = freshModule();
+      pull('dev');
+      assert.ok(cmds.includes('docker info')); // ensureDockerRunning
+      assert.ok(cmds.some(c => c.includes('zip -r /tmp/dev-backup.zip')));
+      assert.ok(cmds.some(c => c.includes('docker-compose up -d --build')));
+    });
+  });
+});
+
+// deploy
+test('deploy runs create and migrations', () => {
+  withTempConfig(() => {
+    withExecStub((cmds) => {
+      const { deploy } = freshModule();
+      deploy('dev');
+      assert.ok(cmds.some(c => c.includes('docker run -d --name pb-dev')));
+      assert.ok(cmds.some(c => c.includes('pocketbase migrate up')));
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- export pb-manage command functions when used as a module
- add `tests/commands.test.js` with unit tests for each command

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6847df5ed8c48331a636a84e2e59f028