### PR TITLE
Add template flag to pb-manage init

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,10 @@ Global options:
 - `--config <file>` – path to a custom `pb.config.json`
 - `--ssh-key <file>` – SSH key for remote commands
 - `--env <name>` – default environment name
+- `--template <path>` – copy files from this directory or git repo when running `init`
 
 Commands:
-- `init` – scaffold config and Docker files
+- `init` – scaffold config and Docker files. Use `--template <path>` to copy a template instead
 - `dev` – start the local Docker environment, apply migrations and seeds, and stream logs
 - `migrate` – run migrations in the local container
 - `seed` – run seeds in the local container

--- a/pb-manage/bin/pb-manage.js
+++ b/pb-manage/bin/pb-manage.js
@@ -3,14 +3,14 @@ const commands = require('../lib/commands');
 const { argv, init, dev, migrate, seed, create, destroy, backup, restore, pull, deploy } = commands;
 
 function usage() {
-  console.log('Usage: pb-manage [--config path] [--ssh-key key] [--env name] <command> [options]');
+  console.log('Usage: pb-manage [--config path] [--ssh-key key] [--env name] [--template path] <command> [options]');
   console.log('Commands: init, dev, migrate, seed, create, destroy, backup, restore, pull, deploy');
 }
 
 if (require.main === module) {
   const cmd = argv._[0];
   if (!cmd) return usage();
-  if (cmd === 'init') init();
+  if (cmd === 'init') init(argv.template);
   else if (cmd === 'dev') dev();
   else if (cmd === 'migrate') migrate();
   else if (cmd === 'seed') seed();

--- a/pb-manage/lib/argv.js
+++ b/pb-manage/lib/argv.js
@@ -1,7 +1,7 @@
 const minimist = require('minimist');
 
 const argv = minimist(process.argv.slice(2), {
-  string: ['config', 'ssh-key', 'env'],
+  string: ['config', 'ssh-key', 'env', 'template'],
   boolean: ['local', 'remote'],
   alias: { c: 'config', k: 'ssh-key', e: 'env' }
 });

--- a/pb-manage/lib/init.js
+++ b/pb-manage/lib/init.js
@@ -1,6 +1,18 @@
-const { ensureDir, writeFileIfMissing } = require('./utils');
+const fs = require('fs');
+const path = require('path');
+const { ensureDir, writeFileIfMissing, run } = require('./utils');
 
-function init() {
+function init(template) {
+  if (template) {
+    if (/^https?:/.test(template) || template.endsWith('.git')) {
+      run(`git clone ${template} .`);
+    } else {
+      const src = path.resolve(template);
+      fs.cpSync(src, process.cwd(), { recursive: true });
+    }
+    return;
+  }
+
   ensureDir('pb_migrations');
   ensureDir('pb_seeds');
   writeFileIfMissing(

--- a/pb-manage/tests/cli.test.js
+++ b/pb-manage/tests/cli.test.js
@@ -27,6 +27,21 @@ test('init creates project files', () => {
   }
 });
 
+test('init copies template files', () => {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), 'pbtest-'));
+  const template = path.join(base, 'tpl');
+  fs.mkdirSync(template);
+  fs.writeFileSync(path.join(template, 'example.txt'), 'hi');
+  const proj = path.join(base, 'proj');
+  fs.mkdirSync(proj);
+  const res = spawnSync('node', [bin, '--template', template, 'init'], {
+    cwd: proj,
+    encoding: 'utf8'
+  });
+  assert.strictEqual(res.status, 0);
+  assert.ok(fs.existsSync(path.join(proj, 'example.txt')));
+});
+
 test('create without env prints error', () => {
   const res = spawnSync('node', [bin, 'create'], { encoding: 'utf8' });
   assert.match(res.stderr, /Missing environment name/);

--- a/pb-manage/tests/commands.test.js
+++ b/pb-manage/tests/commands.test.js
@@ -55,6 +55,17 @@ test('init creates config file', () => {
   });
 });
 
+test('init copies template directory', () => {
+  withTempConfig((dir) => {
+    const tpl = path.join(dir, 'tpl');
+    fs.mkdirSync(tpl);
+    fs.writeFileSync(path.join(tpl, 'foo.txt'), 'bar');
+    const { init } = freshModule();
+    init(tpl);
+    assert.ok(fs.existsSync(path.join(dir, 'foo.txt')));
+  });
+});
+
 // migrate
 test('migrate runs docker migrate', () => {
   withExecStub((cmds) => {


### PR DESCRIPTION
## Summary
- add `--template` arg parsing
- support template cloning/copying in `init`
- document template option
- test new template behavior

## Testing
- `npm test --silent --prefix pb-manage`

------
https://chatgpt.com/codex/tasks/task_e_68491884b30483318b6a7d06ef3c06ed