### PR TITLE
Support custom image for pb-manage

### DIFF
--- a/.github/workflows/pb-deploy.yml
+++ b/.github/workflows/pb-deploy.yml
@@ -9,7 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       REGISTRY: ghcr.io
-      IMAGE: ${{ env.REGISTRY }}/${{ github.repository }}:latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -21,6 +20,8 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
+      - name: Set image tag
+        run: echo "IMAGE=$(node -p \"require('./pb.config.json').image\")" >> $GITHUB_ENV
       - uses: docker/build-push-action@v5
         with:
           context: .

--- a/pb-manage/lib/init.js
+++ b/pb-manage/lib/init.js
@@ -9,7 +9,8 @@ function init() {
       {
         vpsHost: 'your.vps.host',
         sshUser: 'root',
-        domain: 'api.example.com'
+        domain: 'api.example.com',
+        image: 'ghcr.io/your/repo:latest'
       },
       null,
       2
@@ -80,7 +81,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       REGISTRY: ghcr.io
-      IMAGE: \${{ env.REGISTRY }}/\${{ github.repository }}:latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -92,6 +92,8 @@ jobs:
           registry: \${{ env.REGISTRY }}
           username: \${{ secrets.REGISTRY_USERNAME }}
           password: \${{ secrets.REGISTRY_PASSWORD }}
+      - name: Set image tag
+        run: echo "IMAGE=$(node -p \"require('./pb.config.json').image\")" >> $GITHUB_ENV
       - uses: docker/build-push-action@v5
         with:
           context: .

--- a/pb-manage/tests/commands.test.js
+++ b/pb-manage/tests/commands.test.js
@@ -32,7 +32,8 @@ function withTempConfig(fn) {
   const cfg = {
     vpsHost: 'host',
     sshUser: 'root',
-    domain: 'example.com'
+    domain: 'example.com',
+    image: 'my/image:latest'
   };
   fs.writeFileSync(path.join(dir, 'pb.config.json'), JSON.stringify(cfg));
   const cwd = process.cwd();
@@ -89,6 +90,7 @@ test('create issues ssh commands', () => {
       const { create } = freshModule();
       create('dev');
       assert.ok(cmds.some(c => c.includes('docker run -d --name pb-dev')));
+      assert.ok(cmds.some(c => c.includes('my/image:latest')));
     });
   });
 });
@@ -152,6 +154,7 @@ test('deploy runs create and migrations', () => {
       const { deploy } = freshModule();
       deploy('dev');
       assert.ok(cmds.some(c => c.includes('docker run -d --name pb-dev')));
+      assert.ok(cmds.some(c => c.includes('my/image:latest')));
       assert.ok(cmds.some(c => c.includes('pocketbase migrate up')));
     });
   });

--- a/pb.config.json
+++ b/pb.config.json
@@ -1,0 +1,6 @@
+{
+  "vpsHost": "your.vps.host",
+  "sshUser": "root",
+  "domain": "api.example.com",
+  "image": "ghcr.io/your/repo:latest"
+}


### PR DESCRIPTION
## Summary
- add `image` to default `pb.config.json`
- use the configured image when creating or restoring environments
- make the deploy workflow read the image tag from `pb.config.json`
- update tests for the new image handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849189121108331987e7ca9641c23c5