### PR TITLE
Add migrate step to restore

### DIFF
--- a/pb-manage/lib/remote.js
+++ b/pb-manage/lib/remote.js
@@ -56,6 +56,7 @@ function restore(env = argv.env, file) {
   ssh(`docker stop pb-${env} || true`);
   ssh(`unzip -o ${remoteZip} -d ~/pb_data/${env}`);
   ssh(`docker start pb-${env} || docker run -d --name pb-${env} --network pb-net -v ~/pb_data/${env}:/pb/pb_data pocketbase`);
+  ssh(`docker exec pb-${env} pocketbase migrate up`);
   ssh(`rm -f ${remoteZip}`);
 }
 

--- a/pb-manage/tests/commands.test.js
+++ b/pb-manage/tests/commands.test.js
@@ -119,18 +119,19 @@ test('backup pulls backup when local flag set', () => {
 });
 
 // restore
-test('restore uploads and restarts', () => {
-  withTempConfig((dir) => {
-    withExecStub((cmds) => {
-      const file = path.join(dir, 'data.zip');
-      fs.writeFileSync(file, 'dummy');
-      const { restore } = freshModule();
-      restore('dev', file);
-      assert.ok(cmds.some(c => c.startsWith('scp ')));
-      assert.ok(cmds.some(c => c.includes('docker start pb-dev')));
+  test('restore uploads and restarts', () => {
+    withTempConfig((dir) => {
+      withExecStub((cmds) => {
+        const file = path.join(dir, 'data.zip');
+        fs.writeFileSync(file, 'dummy');
+        const { restore } = freshModule();
+        restore('dev', file);
+        assert.ok(cmds.some(c => c.startsWith('scp ')));
+        assert.ok(cmds.some(c => c.includes('docker start pb-dev')));
+        assert.ok(cmds.some(c => c.includes('pocketbase migrate up')));
+      });
     });
   });
-});
 
 // pull
 test('pull grabs remote data', () => {


### PR DESCRIPTION
## Summary
- run `pocketbase migrate up` after restoring a remote backup
- check for the migration command in restore tests

## Testing
- `cd pb-manage && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68491897e0488331b280c40f44172fb6